### PR TITLE
feat(spec): add spec for initializing the state from the route

### DIFF
--- a/specs/initial-state-from-route.spec.ts
+++ b/specs/initial-state-from-route.spec.ts
@@ -1,0 +1,80 @@
+describe('InstantSearch - Initialize state from the route', () => {
+  it('navigates to the e-commerce demo with refinements set in route', async () => {
+    await browser.url(
+      'examples/e-commerce/search/Appliances%2FSmall+Kitchen+Appliances/?query=mixer&page=2&brands=KitchenAid&rating=4&price=50%3A350&free_shipping=true&sortBy=instant_search_price_desc&hitsPerPage=32'
+    );
+  });
+
+  it('must have "mixer" set as initial search box value', async () => {
+    const searchBoxValue = await browser.getSearchBoxValue();
+
+    expect(searchBoxValue).toEqual('mixer');
+  });
+
+  it('must have "Appliances" and "Small Kitchen Appliances" items selected in the category menu', async () => {
+    const items = await browser.getSelectedHierarchicalMenuItems();
+
+    expect(items).toEqual(['Appliances', 'Small Kitchen Appliances']);
+  });
+
+  it('must have "KitchenAid" brand selected in the brands menu', async () => {
+    const brand = await browser.getSelectedRefinementListItem();
+
+    expect(brand).toEqual('KitchenAid');
+  });
+
+  it('must have lower price set to $50 and the upper price set to $350 in the price range', async () => {
+    const lowerPrice = await browser.getRangeSliderLowerBound();
+    const upperPrice = await browser.getRangeSliderUpperBound();
+
+    expect(lowerPrice).toEqual(50);
+    expect(upperPrice).toEqual(350);
+  });
+
+  it('must have free shipping box checked', async () => {
+    const freeShipping = await browser.getToggleRefinementStatus();
+
+    expect(freeShipping).toEqual(true);
+  });
+
+  it('must have rating "4 & up" selected in the rating menu', async () => {
+    const rating = await browser.getRatingMenuValue();
+
+    expect(rating).toEqual('4 & up');
+  });
+
+  it('must have "Price descending" selected in the sort select', async () => {
+    const sortBy = await browser.getSortByValue();
+
+    expect(sortBy).toEqual('instant_search_price_desc');
+  });
+
+  it('must have "32 hits per page" selected in the hits per page select', async () => {
+    const hitsPerPage = await browser.getHitsPerPage();
+
+    expect(hitsPerPage).toEqual(32);
+  });
+
+  it('must have page 2 selected in the pagination', async () => {
+    const page = await browser.getPage();
+
+    expect(page).toEqual(2);
+  });
+
+  it('must have the expected results', async () => {
+    const hitsTitles = await browser.getHitsTitles();
+
+    expect(hitsTitles).toEqual([
+      'KitchenAid - 9-Speed Hand Mixer - Onyx Black',
+      'KitchenAid - Attachment Pack with Citrus Juicer for Most KitchenAid Stand Mixers - White',
+      'KitchenAid - Ice Cream Maker for Most KitchenAid Stand Mixers - White',
+      'KitchenAid - Pasta Sheet Roller for Most KitchenAid Stand Mixers - Silver',
+      'KitchenAid - 7-Speed Hand Mixer - Contour Silver',
+      'KitchenAid - 7-Speed Hand Mixer - Onyx Black',
+      'KitchenAid - 7-Speed Hand Mixer - White',
+      'KitchenAid - 5-Quart Glass Mixing Bowl - Frosted Glass',
+      'KitchenAid - 3-Speed Hand Mixer - Contour Silver',
+      'KitchenAid - 3-Speed Hand Mixer - Onyx Black',
+    ]);
+  });
+});

--- a/specs/initial-state-from-route.spec.ts
+++ b/specs/initial-state-from-route.spec.ts
@@ -1,92 +1,159 @@
-import { URLSearchParams } from 'url';
+import { URL, URLSearchParams } from 'url';
 
-describe('InstantSearch - Initialize state from the route', () => {
-  it('navigates to the e-commerce demo with refinements set in route', async () => {
-    const params = new URLSearchParams({
-      query: 'mixer',
-      page: '2',
-      brands: 'KitchenAid',
-      rating: '4',
-      price: '50:350',
-      free_shipping: 'true', // eslint-disable-line @typescript-eslint/camelcase
-      sortBy: 'instant_search_price_desc',
-      hitsPerPage: '32',
+describe('InstantSearch - State and route', () => {
+  describe('read', () => {
+    it('navigates to the e-commerce demo with refinements set in route', async () => {
+      const params = new URLSearchParams({
+        query: 'mixer',
+        page: '2',
+        brands: 'KitchenAid',
+        rating: '4',
+        price: '50:350',
+        free_shipping: 'true', // eslint-disable-line @typescript-eslint/camelcase
+        sortBy: 'instant_search_price_desc',
+        hitsPerPage: '32',
+      });
+      await browser.url(
+        `examples/e-commerce/search/Appliances%2FSmall+Kitchen+Appliances/?${params.toString()}`
+      );
     });
-    await browser.url(
-      `examples/e-commerce/search/Appliances%2FSmall+Kitchen+Appliances/?${params.toString()}`
-    );
+
+    it('must have "mixer" set as initial search box value', async () => {
+      const searchBoxValue = await browser.getSearchBoxValue();
+
+      expect(searchBoxValue).toEqual('mixer');
+    });
+
+    it('must have "Appliances" and "Small Kitchen Appliances" items selected in the category menu', async () => {
+      const items = await browser.getSelectedHierarchicalMenuItems();
+
+      expect(items).toEqual(['Appliances', 'Small Kitchen Appliances']);
+    });
+
+    it('must have "KitchenAid" brand selected in the brands menu', async () => {
+      const brand = await browser.getSelectedRefinementListItem();
+
+      expect(brand).toEqual('KitchenAid');
+    });
+
+    it('must have lower price set to $50 and the upper price set to $350 in the price range', async () => {
+      const lowerPrice = await browser.getRangeSliderLowerBound();
+      const upperPrice = await browser.getRangeSliderUpperBound();
+
+      expect(lowerPrice).toEqual(50);
+      expect(upperPrice).toEqual(350);
+    });
+
+    it('must have free shipping box checked', async () => {
+      const freeShipping = await browser.getToggleRefinementStatus();
+
+      expect(freeShipping).toEqual(true);
+    });
+
+    it('must have rating "4 & up" selected in the rating menu', async () => {
+      const rating = await browser.getRatingMenuValue();
+
+      expect(rating).toEqual('4 & up');
+    });
+
+    it('must have "Price descending" selected in the sort select', async () => {
+      const sortBy = await browser.getSortByValue();
+
+      expect(sortBy).toEqual('instant_search_price_desc');
+    });
+
+    it('must have "32 hits per page" selected in the hits per page select', async () => {
+      const hitsPerPage = await browser.getHitsPerPage();
+
+      expect(hitsPerPage).toEqual(32);
+    });
+
+    it('must have page 2 selected in the pagination', async () => {
+      const page = await browser.getPage();
+
+      expect(page).toEqual(2);
+    });
+
+    it('must have the expected results', async () => {
+      const hitsTitles = await browser.getHitsTitles();
+
+      expect(hitsTitles).toEqual([
+        'KitchenAid - 9-Speed Hand Mixer - Onyx Black',
+        'KitchenAid - Attachment Pack with Citrus Juicer for Most KitchenAid Stand Mixers - White',
+        'KitchenAid - Ice Cream Maker for Most KitchenAid Stand Mixers - White',
+        'KitchenAid - Pasta Sheet Roller for Most KitchenAid Stand Mixers - Silver',
+        'KitchenAid - 7-Speed Hand Mixer - Contour Silver',
+        'KitchenAid - 7-Speed Hand Mixer - Onyx Black',
+        'KitchenAid - 7-Speed Hand Mixer - White',
+        'KitchenAid - 5-Quart Glass Mixing Bowl - Frosted Glass',
+        'KitchenAid - 3-Speed Hand Mixer - Contour Silver',
+        'KitchenAid - 3-Speed Hand Mixer - Onyx Black',
+      ]);
+    });
   });
 
-  it('must have "mixer" set as initial search box value', async () => {
-    const searchBoxValue = await browser.getSearchBoxValue();
+  describe('write', () => {
+    it('sets "cooktop" as search box value', async () => {
+      await browser.setSearchBoxValue('cooktop');
+    });
 
-    expect(searchBoxValue).toEqual('mixer');
-  });
+    it('deselects "KitchenAid" brand in the brands menu', async () => {
+      await browser.setSelectedRefinementListItem('KitchenAid');
+    });
 
-  it('must have "Appliances" and "Small Kitchen Appliances" items selected in the category menu', async () => {
-    const items = await browser.getSelectedHierarchicalMenuItems();
+    it('deselects "Small Kitchen Appliances" items and select "Ranges, Cooktops & Ovens" in the category menu', async () => {
+      await browser.setSelectedHierarchicalMenuItem('Small Kitchen Appliances');
+      await browser.setSelectedHierarchicalMenuItem('Ranges, Cooktops & Ovens');
+    });
 
-    expect(items).toEqual(['Appliances', 'Small Kitchen Appliances']);
-  });
+    it('selects "Whirlpool" brand in the brands menu', async () => {
+      await browser.setSelectedRefinementListItem('Whirlpool');
+    });
 
-  it('must have "KitchenAid" brand selected in the brands menu', async () => {
-    const brand = await browser.getSelectedRefinementListItem();
+    it('unchecks free shipping box', async () => {
+      await browser.changeToggleRefinementStatus();
+    });
 
-    expect(brand).toEqual('KitchenAid');
-  });
+    it('selects rating "3 & up" in the rating menu', async () => {
+      await browser.setRatingMenuValue('3 & up');
+    });
 
-  it('must have lower price set to $50 and the upper price set to $350 in the price range', async () => {
-    const lowerPrice = await browser.getRangeSliderLowerBound();
-    const upperPrice = await browser.getRangeSliderUpperBound();
+    it('selects "Price ascending" in the sort select', async () => {
+      await browser.setSortByValue('Price ascending');
+    });
 
-    expect(lowerPrice).toEqual(50);
-    expect(upperPrice).toEqual(350);
-  });
+    it('sets lower price to $250 and the upper price to $1250 in the price range', async () => {
+      await browser.setRangeSliderLowerBound(250);
+      await browser.setRangeSliderUpperBound(1250);
+    });
 
-  it('must have free shipping box checked', async () => {
-    const freeShipping = await browser.getToggleRefinementStatus();
+    it('selects "64 hits per page" in the hits per page select', async () => {
+      await browser.setHitsPerPage('64 hits per page');
+    });
 
-    expect(freeShipping).toEqual(true);
-  });
+    it('selects page 2 in the pagination', async () => {
+      await browser.setPage(2);
+    });
 
-  it('must have rating "4 & up" selected in the rating menu', async () => {
-    const rating = await browser.getRatingMenuValue();
+    it('must have the expected url', async () => {
+      await browser.waitUntil(async () => {
+        const url = await browser.getUrl();
+        const { pathname, searchParams } = new URL(url);
 
-    expect(rating).toEqual('4 & up');
-  });
-
-  it('must have "Price descending" selected in the sort select', async () => {
-    const sortBy = await browser.getSortByValue();
-
-    expect(sortBy).toEqual('instant_search_price_desc');
-  });
-
-  it('must have "32 hits per page" selected in the hits per page select', async () => {
-    const hitsPerPage = await browser.getHitsPerPage();
-
-    expect(hitsPerPage).toEqual(32);
-  });
-
-  it('must have page 2 selected in the pagination', async () => {
-    const page = await browser.getPage();
-
-    expect(page).toEqual(2);
-  });
-
-  it('must have the expected results', async () => {
-    const hitsTitles = await browser.getHitsTitles();
-
-    expect(hitsTitles).toEqual([
-      'KitchenAid - 9-Speed Hand Mixer - Onyx Black',
-      'KitchenAid - Attachment Pack with Citrus Juicer for Most KitchenAid Stand Mixers - White',
-      'KitchenAid - Ice Cream Maker for Most KitchenAid Stand Mixers - White',
-      'KitchenAid - Pasta Sheet Roller for Most KitchenAid Stand Mixers - Silver',
-      'KitchenAid - 7-Speed Hand Mixer - Contour Silver',
-      'KitchenAid - 7-Speed Hand Mixer - Onyx Black',
-      'KitchenAid - 7-Speed Hand Mixer - White',
-      'KitchenAid - 5-Quart Glass Mixing Bowl - Frosted Glass',
-      'KitchenAid - 3-Speed Hand Mixer - Contour Silver',
-      'KitchenAid - 3-Speed Hand Mixer - Onyx Black',
-    ]);
+        return (
+          pathname ===
+            '/examples/e-commerce/search/Appliances%2FRanges%2C+Cooktops+%26+Ovens/' &&
+          searchParams.get('query') === 'cooktop' &&
+          searchParams.get('page') === '2' &&
+          searchParams.get('brands') === 'Whirlpool' &&
+          searchParams.get('rating') === '3' &&
+          /^(24[0-9]|250):(124[0-9]|1250)$/.test(
+            searchParams.get('price') || ''
+          ) &&
+          searchParams.get('sortBy') === 'instant_search_price_asc' &&
+          searchParams.get('hitsPerPage') === '64'
+        );
+      });
+    });
   });
 });

--- a/specs/initial-state-from-route.spec.ts
+++ b/specs/initial-state-from-route.spec.ts
@@ -1,7 +1,19 @@
+import { URLSearchParams } from 'url';
+
 describe('InstantSearch - Initialize state from the route', () => {
   it('navigates to the e-commerce demo with refinements set in route', async () => {
+    const params = new URLSearchParams({
+      query: 'mixer',
+      page: '2',
+      brands: 'KitchenAid',
+      rating: '4',
+      price: '50:350',
+      free_shipping: 'true', // eslint-disable-line @typescript-eslint/camelcase
+      sortBy: 'instant_search_price_desc',
+      hitsPerPage: '32',
+    });
     await browser.url(
-      'examples/e-commerce/search/Appliances%2FSmall+Kitchen+Appliances/?query=mixer&page=2&brands=KitchenAid&rating=4&price=50%3A350&free_shipping=true&sortBy=instant_search_price_desc&hitsPerPage=32'
+      `examples/e-commerce/search/Appliances%2FSmall+Kitchen+Appliances/?${params.toString()}`
     );
   });
 


### PR DESCRIPTION
Add a spec for initializing the state from the route.

Will test the following scenario:

1. It navigates to the e-commerce demo with refinements set in route
2. It must have "mixer" set as initial search box value
3. It must have "Appliances" and "Small Kitchen Appliances" items selected in the category menu
4. It must have "KitchenAid" brand selected in the brands menu
5. It must have lower price set to $50 and the upper price set to $350 in the price range
6. It must have free shipping box checked
7. It must have rating "4 & up" selected in the rating menu
8. It must have "Price descending" selected in the sort select
9. It must have "32 hits per page" selected in the hits per page select
10. It must have page 2 selected in the pagination
11. It must have the expected results
12. It sets "cooktop" as search box value
13. It deselects "KitchenAid" brand in the brands menu
14. It deselects "Small Kitchen Appliances" items and select "Ranges, Cooktops & Ovens" in the category menu
15. It selects "Whirlpool" brand in the brands menu
16. It unchecks free shipping box
17. It selects rating "3 & up" in the rating menu
18. It selects "Price ascending" in the sort select
19. It sets lower price to $250 and the upper price to $1250 in the price range
20. It selects "64 hits per page" in the hits per page select
21. It selects page 2 in the pagination
22. It must have the expected url