### PR TITLE
refactor(helper): rename helpers to better reflect underlying user interaction

### DIFF
--- a/helpers/clickClearRefinements.ts
+++ b/helpers/clickClearRefinements.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    clearRefinements(): Promise<boolean>;
+    clickClearRefinements(): Promise<boolean>;
   }
 }
 
-browser.addCommand('clearRefinements', async () => {
+browser.addCommand('clickClearRefinements', async () => {
   const clearButton = await browser.$(`.ais-ClearRefinements-button`);
 
   await clearButton.click();

--- a/helpers/clickHierarchicalMenuItem.ts
+++ b/helpers/clickHierarchicalMenuItem.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setSelectedHierarchicalMenuItem(label: string): Promise<boolean>;
+    clickHierarchicalMenuItem(label: string): Promise<boolean>;
   }
 }
 
-browser.addCommand('setSelectedHierarchicalMenuItem', async (label: string) => {
+browser.addCommand('clickHierarchicalMenuItem', async (label: string) => {
   const oldUrl = await browser.getUrl();
   const item = await browser.$(`.ais-HierarchicalMenu-label=${label}`);
   await item.click();

--- a/helpers/clickNextPage.ts
+++ b/helpers/clickNextPage.ts
@@ -1,11 +1,11 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setNextPage(): Promise<boolean>;
+    clickNextPage(): Promise<boolean>;
   }
 }
 
-browser.addCommand('setNextPage', async () => {
-  const pageNumber = await browser.getPage();
+browser.addCommand('clickNextPage', async () => {
+  const pageNumber = await browser.getCurrentPage();
   const page = await browser.$(
     `.ais-Pagination-item--nextPage .ais-Pagination-link`
   );

--- a/helpers/clickPage.ts
+++ b/helpers/clickPage.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setPage(number: number): Promise<boolean>;
+    clickPage(number: number): Promise<boolean>;
   }
 }
 
-browser.addCommand('setPage', async (number: number) => {
+browser.addCommand('clickPage', async (number: number) => {
   const page = await browser.$(`.ais-Pagination-link=${number}`);
 
   await page.click();

--- a/helpers/clickPreviousPage.ts
+++ b/helpers/clickPreviousPage.ts
@@ -1,11 +1,11 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setPreviousPage(): Promise<boolean>;
+    clickPreviousPage(): Promise<boolean>;
   }
 }
 
-browser.addCommand('setPreviousPage', async () => {
-  const pageNumber = await browser.getPage();
+browser.addCommand('clickPreviousPage', async () => {
+  const pageNumber = await browser.getCurrentPage();
   const page = await browser.$(
     `.ais-Pagination-item--previousPage .ais-Pagination-link`
   );

--- a/helpers/clickRatingMenuItem.ts
+++ b/helpers/clickRatingMenuItem.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setRatingMenuValue(label: string): Promise<boolean>;
+    clickRatingMenuItem(label: string): Promise<boolean>;
   }
 }
 
-browser.addCommand('setRatingMenuValue', async (label: string) => {
+browser.addCommand('clickRatingMenuItem', async (label: string) => {
   const rating = await browser.$(`.ais-RatingMenu-link[aria-label="${label}"]`);
 
   await rating.click();

--- a/helpers/clickRefinementListItem.ts
+++ b/helpers/clickRefinementListItem.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setSelectedRefinementListItem(label: string): Promise<boolean>;
+    clickRefinementListItem(label: string): Promise<boolean>;
   }
 }
 
-browser.addCommand('setSelectedRefinementListItem', async (label: string) => {
+browser.addCommand('clickRefinementListItem', async (label: string) => {
   const oldUrl = await browser.getUrl();
   const item = await browser.$(`.ais-RefinementList-labelText=${label}`);
   await item.click();

--- a/helpers/clickToggleRefinement.ts
+++ b/helpers/clickToggleRefinement.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    toggleToggleRefinementStatus(): Promise<boolean>;
+    clickToggleRefinement(): Promise<boolean>;
   }
 }
 
-browser.addCommand('toggleToggleRefinementStatus', async () => {
+browser.addCommand('clickToggleRefinement', async () => {
   const checkbox = await browser.$('.ais-ToggleRefinement-checkbox');
 
   return checkbox.click();

--- a/helpers/dragRangeSliderLowerBoundTo.ts
+++ b/helpers/dragRangeSliderLowerBoundTo.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setRangeSliderLowerBound(value: number): Promise<number>;
+    dragRangeSliderLowerBoundTo(value: number): Promise<number>;
   }
 }
 
-browser.addCommand('setRangeSliderLowerBound', async (value: number) => {
+browser.addCommand('dragRangeSliderLowerBoundTo', async (value: number) => {
   const slider = await browser.$('.rheostat-horizontal');
   let lowerHandle = await browser.$('.ais-RangeSlider .rheostat-handle-lower');
   const upperHandle = await browser.$(

--- a/helpers/dragRangeSliderUpperBoundTo.ts
+++ b/helpers/dragRangeSliderUpperBoundTo.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    setRangeSliderUpperBound(value: number): Promise<number>;
+    dragRangeSliderUpperBoundTo(value: number): Promise<number>;
   }
 }
 
-browser.addCommand('setRangeSliderUpperBound', async (value: number) => {
+browser.addCommand('dragRangeSliderUpperBoundTo', async (value: number) => {
   const slider = await browser.$('.rheostat-horizontal');
   const lowerHandle = await browser.$(
     '.ais-RangeSlider .rheostat-handle-lower'

--- a/helpers/getCurrentPage.ts
+++ b/helpers/getCurrentPage.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    getPage(): Promise<number>;
+    getCurrentPage(): Promise<number>;
   }
 }
 
-browser.addCommand('getPage', async () => {
+browser.addCommand('getCurrentPage', async () => {
   const page = await browser.$('.ais-Pagination-item--selected');
 
   return Number(await page.getText());

--- a/helpers/getRangeSliderLowerBoundValue.ts
+++ b/helpers/getRangeSliderLowerBoundValue.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    getRangeSliderLowerBound(): Promise<number>;
+    getRangeSliderLowerBoundValue(): Promise<number>;
   }
 }
 
-browser.addCommand('getRangeSliderLowerBound', async () => {
+browser.addCommand('getRangeSliderLowerBoundValue', async () => {
   const lowerHandle = await browser.$(
     '.ais-RangeSlider .rheostat-handle-lower'
   );

--- a/helpers/getRangeSliderUpperBoundValue.ts
+++ b/helpers/getRangeSliderUpperBoundValue.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    getRangeSliderUpperBound(): Promise<number>;
+    getRangeSliderUpperBoundValue(): Promise<number>;
   }
 }
 
-browser.addCommand('getRangeSliderUpperBound', async () => {
+browser.addCommand('getRangeSliderUpperBoundValue', async () => {
   const upperHandle = await browser.$(
     '.ais-RangeSlider .rheostat-handle-upper'
   );

--- a/helpers/getSelectedRatingMenuItem.ts
+++ b/helpers/getSelectedRatingMenuItem.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    getRatingMenuValue(): Promise<string>;
+    getSelectedRatingMenuItem(): Promise<string>;
   }
 }
 
-browser.addCommand('getRatingMenuValue', async () => {
+browser.addCommand('getSelectedRatingMenuItem', async () => {
   const rating = await browser.$(
     '.ais-RatingMenu-item--selected .ais-RatingMenu-link'
   );

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -12,34 +12,34 @@ import './getHitsTitles';
 
 // RefinementList
 import './getSelectedRefinementListItem';
-import './setSelectedRefinementListItem';
+import './clickRefinementListItem';
 
 // HierarchicalMenu
 import './getSelectedHierarchicalMenuItems';
-import './setSelectedHierarchicalMenuItem';
+import './clickHierarchicalMenuItem';
 
 // RangeSlider
-import './getRangeSliderLowerBound';
-import './setRangeSliderLowerBound';
-import './getRangeSliderUpperBound';
-import './setRangeSliderUpperBound';
+import './getRangeSliderLowerBoundValue';
+import './dragRangeSliderLowerBoundTo';
+import './getRangeSliderUpperBoundValue';
+import './dragRangeSliderUpperBoundTo';
 
 // ToggleRefinement
 import './getToggleRefinementStatus';
-import './changeToggleRefinementStatus';
+import './toggleToggleRefinementStatus';
 
 // RatingMenu
-import './getRatingMenuValue';
-import './setRatingMenuValue';
+import './getSelectedRatingMenuItem';
+import './clickRatingMenuItem';
 
 // ClearRefinements
-import './clearRefinements';
+import './clickClearRefinements';
 
 // Pagination
-import './getPage';
-import './setPage';
-import './setNextPage';
-import './setPreviousPage';
+import './getCurrentPage';
+import './clickPage';
+import './clickNextPage';
+import './clickPreviousPage';
 
 // HitsPerPage
 import './getHitsPerPage';

--- a/helpers/index.ts
+++ b/helpers/index.ts
@@ -26,7 +26,7 @@ import './dragRangeSliderUpperBoundTo';
 
 // ToggleRefinement
 import './getToggleRefinementStatus';
-import './toggleToggleRefinementStatus';
+import './clickToggleRefinement';
 
 // RatingMenu
 import './getSelectedRatingMenuItem';

--- a/helpers/toggleToggleRefinementStatus.ts
+++ b/helpers/toggleToggleRefinementStatus.ts
@@ -1,10 +1,10 @@
 declare namespace WebdriverIOAsync {
   interface Browser {
-    changeToggleRefinementStatus(): Promise<boolean>;
+    toggleToggleRefinementStatus(): Promise<boolean>;
   }
 }
 
-browser.addCommand('changeToggleRefinementStatus', async () => {
+browser.addCommand('toggleToggleRefinementStatus', async () => {
   const checkbox = await browser.$('.ais-ToggleRefinement-checkbox');
 
   return checkbox.click();

--- a/specs/brand-and-query.spec.ts
+++ b/specs/brand-and-query.spec.ts
@@ -4,7 +4,7 @@ describe('InstantSearch - Search on specific brand and query filtering', () => {
   });
 
   it('selects "Apple" brand in list', async () => {
-    await browser.setSelectedRefinementListItem('Apple');
+    await browser.clickRefinementListItem('Apple');
   });
 
   it('fills search input with "macbook"', async () => {

--- a/specs/category.spec.ts
+++ b/specs/category.spec.ts
@@ -4,11 +4,11 @@ describe('InstantSearch - Search on specific category', () => {
   });
 
   it('selects "Appliances" category in list', async () => {
-    await browser.setSelectedHierarchicalMenuItem('Appliances');
+    await browser.clickHierarchicalMenuItem('Appliances');
   });
 
   it('selects "Small Kitchen Appliances" category in list', async () => {
-    await browser.setSelectedHierarchicalMenuItem('Small Kitchen Appliances');
+    await browser.clickHierarchicalMenuItem('Small Kitchen Appliances');
   });
 
   it('must have the expected results for "Small Kitchen Appliances"', async () => {
@@ -35,7 +35,7 @@ describe('InstantSearch - Search on specific category', () => {
   });
 
   it('unselects "Small Kitchen Appliances" category in list', async () => {
-    await browser.setSelectedHierarchicalMenuItem('Small Kitchen Appliances');
+    await browser.clickHierarchicalMenuItem('Small Kitchen Appliances');
   });
 
   it('must have the expected results for "Appliances"', async () => {

--- a/specs/initial-state-from-route.spec.ts
+++ b/specs/initial-state-from-route.spec.ts
@@ -37,8 +37,8 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('must have lower price set to $50 and the upper price set to $350 in the price range', async () => {
-      const lowerPrice = await browser.getRangeSliderLowerBound();
-      const upperPrice = await browser.getRangeSliderUpperBound();
+      const lowerPrice = await browser.getRangeSliderLowerBoundValue();
+      const upperPrice = await browser.getRangeSliderUpperBoundValue();
 
       expect(lowerPrice).toEqual(50);
       expect(upperPrice).toEqual(350);
@@ -51,7 +51,7 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('must have rating "4 & up" selected in the rating menu', async () => {
-      const rating = await browser.getRatingMenuValue();
+      const rating = await browser.getSelectedRatingMenuItem();
 
       expect(rating).toEqual('4 & up');
     });
@@ -69,7 +69,7 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('must have page 2 selected in the pagination', async () => {
-      const page = await browser.getPage();
+      const page = await browser.getCurrentPage();
 
       expect(page).toEqual(2);
     });
@@ -98,24 +98,24 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('deselects "KitchenAid" brand in the brands menu', async () => {
-      await browser.setSelectedRefinementListItem('KitchenAid');
+      await browser.clickRefinementListItem('KitchenAid');
     });
 
     it('deselects "Small Kitchen Appliances" items and select "Ranges, Cooktops & Ovens" in the category menu', async () => {
-      await browser.setSelectedHierarchicalMenuItem('Small Kitchen Appliances');
-      await browser.setSelectedHierarchicalMenuItem('Ranges, Cooktops & Ovens');
+      await browser.clickHierarchicalMenuItem('Small Kitchen Appliances');
+      await browser.clickHierarchicalMenuItem('Ranges, Cooktops & Ovens');
     });
 
     it('selects "Whirlpool" brand in the brands menu', async () => {
-      await browser.setSelectedRefinementListItem('Whirlpool');
+      await browser.clickRefinementListItem('Whirlpool');
     });
 
     it('unchecks free shipping box', async () => {
-      await browser.changeToggleRefinementStatus();
+      await browser.clickToggleRefinement();
     });
 
     it('selects rating "3 & up" in the rating menu', async () => {
-      await browser.setRatingMenuValue('3 & up');
+      await browser.clickRatingMenuItem('3 & up');
     });
 
     it('selects "Price ascending" in the sort select', async () => {
@@ -123,8 +123,8 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('sets lower price to $250 and the upper price to $1250 in the price range', async () => {
-      await browser.setRangeSliderLowerBound(250);
-      await browser.setRangeSliderUpperBound(1250);
+      await browser.dragRangeSliderLowerBoundTo(250);
+      await browser.dragRangeSliderUpperBoundTo(1250);
     });
 
     it('selects "64 hits per page" in the hits per page select', async () => {
@@ -132,7 +132,7 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('selects page 2 in the pagination', async () => {
-      await browser.setPage(2);
+      await browser.clickPage(2);
     });
 
     it('must have the expected url', async () => {

--- a/specs/pagination.spec.ts
+++ b/specs/pagination.spec.ts
@@ -4,7 +4,7 @@ describe('InstantSearch - Page navigation', () => {
   });
 
   it('navigates to next page', async () => {
-    await browser.setNextPage();
+    await browser.clickNextPage();
   });
 
   it('must have the expected results for page 2', async () => {
@@ -31,11 +31,11 @@ describe('InstantSearch - Page navigation', () => {
   });
 
   it('selects "Appliances" in the category menu', async () => {
-    await browser.setSelectedHierarchicalMenuItem('Appliances');
+    await browser.clickHierarchicalMenuItem('Appliances');
   });
 
   it('must reset the page to 1', async () => {
-    const page = await browser.getPage();
+    const page = await browser.getCurrentPage();
 
     expect(page).toEqual(1);
   });
@@ -64,7 +64,7 @@ describe('InstantSearch - Page navigation', () => {
   });
 
   it('navigates to page 3', async () => {
-    await browser.setPage(3);
+    await browser.clickPage(3);
   });
 
   it('must have the expected results for page 3', async () => {

--- a/specs/price-range.spec.ts
+++ b/specs/price-range.spec.ts
@@ -7,7 +7,7 @@ describe('InstantSearch - Search on specific price range', () => {
   });
 
   it('drag and drop lower handle to the right', async () => {
-    lowerBound = await browser.setRangeSliderLowerBound(971);
+    lowerBound = await browser.dragRangeSliderLowerBoundTo(971);
   });
 
   it(`waits for the results list to be updated (wait for all the prices to be > lowerBound)`, async () => {
@@ -22,7 +22,7 @@ describe('InstantSearch - Search on specific price range', () => {
   });
 
   it('drag and drop upper handle to the left', async () => {
-    upperBound = await browser.setRangeSliderUpperBound(1971);
+    upperBound = await browser.dragRangeSliderUpperBoundTo(1971);
   });
 
   it(`waits for the results list to be updated (wait for all the prices to be < upperBound)`, async () => {


### PR DESCRIPTION
As asked in https://github.com/algolia/instantsearch-e2e-tests/pull/3#discussion_r317518388, this PR rename some helpers to better reflect the underlying user interaction.

List of changes:

| Before                            | After
|-----------------------------------|-------------------------------
| `clearRefinements`                | `clickClearRefinements`
| `setSelectedHierarchicalMenuItem` | `clickHierarchicalMenuItem`
| `setNextPage`                     | `clickNextPage`
| `setPage`                         | `clickPage`
| `setPreviousPage`                 | `clickPreviousPage`
| `setRatingMenuValue`              | `clickRatingMenuItem`
| `setSelectedRefinementListItem`   | `clickRefinementListItem`
| `setRangeSliderLowerBound`        | `dragRangeSliderLowerBoundTo`
| `setRangeSliderUpperBound`        | `dragRangeSliderUpperBoundTo`
| `getPage`                         | `getCurrentPage`
| `getRangeSliderLowerBound`        | `getRangeSliderLowerBoundValue`
| `getRangeSliderUpperBound`        | `getRangeSliderUpperBoundValue`
| `getRatingMenuValue`              | `getSelectedRatingMenuItem`
| `changeToggleRefinementStatus`    | `toggleToggleRefinementStatus`

