### PR TITLE
fix(helper): fix helpers to scroll to elements before attempting to click on it

### DIFF
--- a/helpers/changeToggleRefinementStatus.ts
+++ b/helpers/changeToggleRefinementStatus.ts
@@ -6,6 +6,8 @@ declare namespace WebdriverIOAsync {
 
 browser.addCommand('changeToggleRefinementStatus', async () => {
   const checkbox = await browser.$('.ais-ToggleRefinement-checkbox');
+  // Assures us that the element is in the viewport
+  await checkbox.scrollIntoView();
 
   return checkbox.click();
 });

--- a/helpers/clearRefinements.ts
+++ b/helpers/clearRefinements.ts
@@ -6,6 +6,8 @@ declare namespace WebdriverIOAsync {
 
 browser.addCommand('clearRefinements', async () => {
   const clearButton = await browser.$(`.ais-ClearRefinements-button`);
+  // Assures us that the element is in the viewport
+  await clearButton.scrollIntoView();
 
   await clearButton.click();
 

--- a/helpers/setNextPage.ts
+++ b/helpers/setNextPage.ts
@@ -9,6 +9,8 @@ browser.addCommand('setNextPage', async () => {
   const page = await browser.$(
     `.ais-Pagination-item--nextPage .ais-Pagination-link`
   );
+  // Assures us that the element is in the viewport
+  await page.scrollIntoView();
 
   await page.click();
 

--- a/helpers/setPage.ts
+++ b/helpers/setPage.ts
@@ -6,6 +6,8 @@ declare namespace WebdriverIOAsync {
 
 browser.addCommand('setPage', async (number: number) => {
   const page = await browser.$(`.ais-Pagination-link=${number}`);
+  // Assures us that the element is in the viewport
+  await page.scrollIntoView();
 
   await page.click();
 

--- a/helpers/setPreviousPage.ts
+++ b/helpers/setPreviousPage.ts
@@ -9,6 +9,8 @@ browser.addCommand('setPreviousPage', async () => {
   const page = await browser.$(
     `.ais-Pagination-item--previousPage .ais-Pagination-link`
   );
+  // Assures us that the element is in the viewport
+  await page.scrollIntoView();
 
   await page.click();
 

--- a/helpers/setRatingMenuValue.ts
+++ b/helpers/setRatingMenuValue.ts
@@ -6,6 +6,8 @@ declare namespace WebdriverIOAsync {
 
 browser.addCommand('setRatingMenuValue', async (label: string) => {
   const rating = await browser.$(`.ais-RatingMenu-link[aria-label="${label}"]`);
+  // Assures us that the element is in the viewport
+  await rating.scrollIntoView();
 
   await rating.click();
 

--- a/helpers/setSearchBoxValue.ts
+++ b/helpers/setSearchBoxValue.ts
@@ -7,6 +7,8 @@ declare namespace WebdriverIOAsync {
 browser.addCommand('setSearchBoxValue', async (value: string) => {
   const oldUrl = await browser.getUrl();
   const searchBox = await browser.$('.ais-SearchBox [type=search]');
+  // Assures us that the element is in the viewport
+  await searchBox.scrollIntoView();
   // In Internet Explorer the input must be focused before updating its value
   await searchBox.click();
   await searchBox.setValue(value);

--- a/helpers/setSelectedHierarchicalMenuItem.ts
+++ b/helpers/setSelectedHierarchicalMenuItem.ts
@@ -7,6 +7,9 @@ declare namespace WebdriverIOAsync {
 browser.addCommand('setSelectedHierarchicalMenuItem', async (label: string) => {
   const oldUrl = await browser.getUrl();
   const item = await browser.$(`.ais-HierarchicalMenu-label=${label}`);
+  // Assures us that the element is in the viewport
+  await item.scrollIntoView();
+
   await item.click();
 
   // Changing the URL will also change the page element IDs in Internet Explorer

--- a/helpers/setSelectedRefinementListItem.ts
+++ b/helpers/setSelectedRefinementListItem.ts
@@ -7,6 +7,9 @@ declare namespace WebdriverIOAsync {
 browser.addCommand('setSelectedRefinementListItem', async (label: string) => {
   const oldUrl = await browser.getUrl();
   const item = await browser.$(`.ais-RefinementList-labelText=${label}`);
+  // Assures us that the element is in the viewport
+  await item.scrollIntoView();
+
   await item.click();
 
   // Changing the URL will also change the page element IDs in Internet Explorer


### PR DESCRIPTION
Some click events can fail in some browsers (IE in particular) if the target element is not in the viewport.

This change updates all helpers that trigger click events to scroll to the target element before attempting to click on it.