### PR TITLE
fix(helper): fix helpers to handle RangeSlider in react-instantsearch

### DIFF
--- a/helpers/dragRangeSliderLowerBoundTo.ts
+++ b/helpers/dragRangeSliderLowerBoundTo.ts
@@ -5,11 +5,13 @@ declare namespace WebdriverIOAsync {
 }
 
 browser.addCommand('dragRangeSliderLowerBoundTo', async (value: number) => {
-  const slider = await browser.$('.rheostat-horizontal');
-  let lowerHandle = await browser.$('.ais-RangeSlider .rheostat-handle-lower');
-  const upperHandle = await browser.$(
-    '.ais-RangeSlider .rheostat-handle-upper'
+  const slider = await browser.$('.slider-rail, .rheostat-background');
+
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  let [lowerHandle, upperHandle] = await browser.$$(
+    '.slider-handle, .rheostat-handle'
   );
+
   const { width: sliderWidth } = await slider.getSize();
   const { x: lowerHandleX } = await lowerHandle.getLocation();
   const { x: sliderX } = await slider.getLocation();
@@ -32,6 +34,9 @@ browser.addCommand('dragRangeSliderLowerBoundTo', async (value: number) => {
   // Depending of the steps calculation there can be a difference between
   // the wanted value and the actual value of the slider, so we return
   // the actual value in case we need it in the rest of the tests
-  lowerHandle = await browser.$('.ais-RangeSlider .rheostat-handle-lower');
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  [lowerHandle, upperHandle] = await browser.$$(
+    '.slider-handle, .rheostat-handle'
+  );
   return Number(await lowerHandle.getAttribute('aria-valuenow'));
 });

--- a/helpers/dragRangeSliderUpperBoundTo.ts
+++ b/helpers/dragRangeSliderUpperBoundTo.ts
@@ -5,11 +5,13 @@ declare namespace WebdriverIOAsync {
 }
 
 browser.addCommand('dragRangeSliderUpperBoundTo', async (value: number) => {
-  const slider = await browser.$('.rheostat-horizontal');
-  const lowerHandle = await browser.$(
-    '.ais-RangeSlider .rheostat-handle-lower'
+  const slider = await browser.$('.slider-rail, .rheostat-background');
+
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  let [lowerHandle, upperHandle] = await browser.$$(
+    '.slider-handle, .rheostat-handle'
   );
-  let upperHandle = await browser.$('.ais-RangeSlider .rheostat-handle-upper');
+
   const { width: sliderWidth } = await slider.getSize();
   const { x: upperHandleX } = await upperHandle.getLocation();
   const { x: sliderX } = await slider.getLocation();
@@ -32,6 +34,9 @@ browser.addCommand('dragRangeSliderUpperBoundTo', async (value: number) => {
   // Depending of the steps calculation there can be a difference between
   // the wanted value and the actual value of the slider, so we return
   // the actual value in case we need it in the rest of the tests
-  upperHandle = await browser.$('.ais-RangeSlider .rheostat-handle-upper');
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  [lowerHandle, upperHandle] = await browser.$$(
+    '.slider-handle, .rheostat-handle'
+  );
   return Number(await upperHandle.getAttribute('aria-valuenow'));
 });

--- a/helpers/getRangeSliderLowerBoundValue.ts
+++ b/helpers/getRangeSliderLowerBoundValue.ts
@@ -5,8 +5,7 @@ declare namespace WebdriverIOAsync {
 }
 
 browser.addCommand('getRangeSliderLowerBoundValue', async () => {
-  const lowerHandle = await browser.$(
-    '.ais-RangeSlider .rheostat-handle-lower'
-  );
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  const [lowerHandle] = await browser.$$('.slider-handle, .rheostat-handle');
   return Number(await lowerHandle.getAttribute('aria-valuenow'));
 });

--- a/helpers/getRangeSliderUpperBoundValue.ts
+++ b/helpers/getRangeSliderUpperBoundValue.ts
@@ -5,8 +5,7 @@ declare namespace WebdriverIOAsync {
 }
 
 browser.addCommand('getRangeSliderUpperBoundValue', async () => {
-  const upperHandle = await browser.$(
-    '.ais-RangeSlider .rheostat-handle-upper'
-  );
+  await browser.waitForElement('.slider-handle, .rheostat-handle');
+  const [, upperHandle] = await browser.$$('.slider-handle, .rheostat-handle');
   return Number(await upperHandle.getAttribute('aria-valuenow'));
 });


### PR DESCRIPTION
In `react-instantsearch` the `RangeSlider` widget has some different HTML structure and CSS classes.

This change updates the `dragRangeSliderLowerBoundTo`, `dragRangeSliderUpperBoundTo`, `getRangeSliderLowerBoundValue` and `getRangeSliderUpperBoundValue` helpers to find the wanted elements using different CSS classes.