### PR TITLE
test: add commands to run all test suite on InstantSearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,46 @@
+aliases:
+  - &install_yarn_version
+    name: Install specific Yarn version
+    command: |
+      curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.13.0
+      echo 'export PATH="$HOME/.yarn/bin:$HOME/.config/yarn/global/node_modules/.bin:$PATH"' >> $BASH_ENV
+
+  - &restore_yarn_cache
+    name: Restore Yarn cache
+    keys:
+      - yarn-{{ .Branch }}-packages-{{ checksum "yarn.lock" }}
+
+  - &save_yarn_cache
+    name: Save Yarn cache
+    key: yarn-{{ .Branch }}-packages-{{ checksum "yarn.lock" }}
+    paths:
+      - ~/.cache/yarn
+
+  - &run_yarn_install
+    name: Install dependencies
+    command: yarn install
+
+defaults: &defaults
+  working_directory: ~/instantsearch-e2-tests
+  docker:
+    - image: circleci/node:10.16.3@sha256:6ab62742cec4a68e75e7cac063f6549bae0bcfd0541700df7fde54765eed4ad2
+
+version: 2
+jobs:
+  test:
+    <<: *defaults
+    steps:
+      - checkout
+      - run: *install_yarn_version
+      - restore_cache: *restore_yarn_cache
+      - run: *run_yarn_install
+      - save_cache: *save_yarn_cache
+      - run:
+          name: Test specs
+          command: yarn test:saucelabs
+
+workflows:
+  version: 2
+  ci:
+    jobs:
+      - test

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules/
+tests/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules/
 npm-debug.log
 yarn-error.log
 .DS_Store
+tests/*
+!tests/*.sh

--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   "scripts": {
     "commit": "git-cz",
     "version": "conventional-changelog --preset angular --infile CHANGELOG.md --same-file && git add CHANGELOG.md",
+    "test": "yarn test:local",
+    "test:local": "yarn link && cd tests && ./instantsearch.js.sh && ./react-instantsearch.sh && ./vue-instantsearch.sh",
+    "test:saucelabs": "yarn link && cd tests && (export SAUCELABS=1 && ./instantsearch.js.sh && ./react-instantsearch.sh && ./vue-instantsearch.sh)",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.ts,.tsx --fix .",
     "type-check": "tsc",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "version": "conventional-changelog --preset angular --infile CHANGELOG.md --same-file && git add CHANGELOG.md",
     "test": "yarn test:local",
     "test:local": "yarn link && cd tests && ./instantsearch.js.sh && ./react-instantsearch.sh && ./vue-instantsearch.sh",
-    "test:saucelabs": "yarn link && cd tests && (export SAUCELABS=1 && ./instantsearch.js.sh && ./react-instantsearch.sh && ./vue-instantsearch.sh)",
+    "test:saucelabs": "SAUCELABS=1 yarn test:local",
     "lint": "eslint --ext .js,.ts,.tsx .",
     "lint:fix": "eslint --ext .js,.ts,.tsx --fix .",
     "type-check": "tsc",

--- a/tests/instantsearch.js.sh
+++ b/tests/instantsearch.js.sh
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf instantsearch.js
-git clone git@github.com:algolia/instantsearch.js.git --branch master --depth=1
+git clone git@github.com:algolia/instantsearch.js.git --branch develop --depth=1
 cd instantsearch.js
 yarn --ignore-engines
 yarn link instantsearch-e2e-tests

--- a/tests/instantsearch.js.sh
+++ b/tests/instantsearch.js.sh
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf instantsearch.js
-git clone git@github.com:algolia/instantsearch.js.git --depth=1
+git clone git@github.com:algolia/instantsearch.js.git --branch master --depth=1
 cd instantsearch.js
 yarn --ignore-engines
 yarn link instantsearch-e2e-tests

--- a/tests/instantsearch.js.sh
+++ b/tests/instantsearch.js.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf instantsearch.js
+git clone git@github.com:algolia/instantsearch.js.git --depth=1
+cd instantsearch.js
+yarn --ignore-engines
+yarn link instantsearch-e2e-tests
+yarn run website:build
+if [ "$SAUCELABS" ]; then
+  yarn run test:e2e:saucelabs
+else
+  yarn run test:e2e
+fi

--- a/tests/react-instantsearch.sh
+++ b/tests/react-instantsearch.sh
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf react-instantsearch
-git clone git@github.com:algolia/react-instantsearch.git --depth=1
+git clone git@github.com:algolia/react-instantsearch.git --branch master --depth=1
 cd react-instantsearch
 yarn --ignore-engines
 yarn link instantsearch-e2e-tests

--- a/tests/react-instantsearch.sh
+++ b/tests/react-instantsearch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf react-instantsearch
+git clone git@github.com:algolia/react-instantsearch.git --depth=1
+cd react-instantsearch
+yarn --ignore-engines
+yarn link instantsearch-e2e-tests
+yarn run website:build
+if [ "$SAUCELABS" ]; then
+  yarn run test:e2e:saucelabs
+else
+  yarn run test:e2e
+fi

--- a/tests/vue-instantsearch.sh
+++ b/tests/vue-instantsearch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+rm -rf vue-instantsearch
+git clone git@github.com:algolia/vue-instantsearch.git --depth=1
+cd vue-instantsearch
+yarn --ignore-engines
+yarn link instantsearch-e2e-tests
+yarn run examples:build
+if [ "$SAUCELABS" ]; then
+  yarn run test:e2e:saucelabs
+else
+  yarn run test:e2e
+fi

--- a/tests/vue-instantsearch.sh
+++ b/tests/vue-instantsearch.sh
@@ -3,7 +3,7 @@
 set -e
 
 rm -rf vue-instantsearch
-git clone git@github.com:algolia/vue-instantsearch.git --depth=1
+git clone git@github.com:algolia/vue-instantsearch.git --branch master --depth=1
 cd vue-instantsearch
 yarn --ignore-engines
 yarn link instantsearch-e2e-tests

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,5 +11,6 @@
     "noFallthroughCasesInSwitch": true,
     "allowSyntheticDefaultImports": true,
     "types": ["node", "webdriverio", "jasmine"]
-  }
+  },
+  "exclude": ["node_modules", "tests"]
 }


### PR DESCRIPTION
Run the test suite on the different flavors to check that we did not break anything while doing a change on the tests.

The tests are run on SauceLabs on CircleCI and can be run locally or on SauceLabs using the `yarn test:local` and `yarn test:saucelabs` commands.