### PR TITLE
fix(setSearchBoxValue): reset searchbox before editing

### DIFF
--- a/helpers/setSearchBoxValue.ts
+++ b/helpers/setSearchBoxValue.ts
@@ -7,8 +7,17 @@ declare namespace WebdriverIOAsync {
 browser.addCommand('setSearchBoxValue', async (value: string) => {
   const oldUrl = await browser.getUrl();
   const searchBox = await browser.$('.ais-SearchBox [type=search]');
+  const resetButton = await browser.$('.ais-SearchBox [type=reset]');
+
   // Assures us that the element is in the viewport
   await searchBox.scrollIntoView();
+
+  // Click the reset button to clear the input
+  if (resetButton.isDisplayed()) {
+    // The reset button is invisible when nothing to reset
+    await resetButton.click();
+  }
+
   // In Internet Explorer the input must be focused before updating its value
   await searchBox.click();
   await searchBox.setValue(value);

--- a/helpers/setSearchBoxValue.ts
+++ b/helpers/setSearchBoxValue.ts
@@ -13,7 +13,7 @@ browser.addCommand('setSearchBoxValue', async (value: string) => {
   await searchBox.scrollIntoView();
 
   // Click the reset button to clear the input
-  if (resetButton.isDisplayed()) {
+  if (await resetButton.isDisplayed()) {
     // The reset button is invisible when nothing to reset
     await resetButton.click();
   }


### PR DESCRIPTION
In React and Preact the CLEAR selenium instruction does not fire any event, and therefore does not update the component's internal state (see this job for example: https://app.saucelabs.com/tests/4518f96fdfd447e998786d0ff463658a#54)

It is equivalent to `input.value = ''`.

There are multiple sources reporting a similar behaviour (see https://github.com/SeleniumHQ/selenium/issues/6741)

Since this change: https://github.com/algolia/instantsearch.js/pull/4202

```jsx
<input value={state.query} />
```

instead of 

```jsx
<input value={props.query} />
```
Since binding the input value to a `state.query` (rather than a `props.query`), it appears the click we use to focus on the searchbox re-syncs `input.value` with `state.query`.

Demonstration of the issue:
- **Before  https://github.com/algolia/instantsearch.js/pull/4202**:
  ![2019-11-21 13 43 15](https://user-images.githubusercontent.com/2982512/69339503-c3893200-0c65-11ea-9716-b1490b341ae6.gif)
- **After https://github.com/algolia/instantsearch.js/pull/4202**:
  ![2019-11-21 13 43 52](https://user-images.githubusercontent.com/2982512/69339497-bff5ab00-0c65-11ea-838f-f9e2ffc164bd.gif)











