### PR TITLE
feat(webdriverio): add retry for Sauce Connect tunnel

### DIFF
--- a/wdio.saucelabs.conf.js
+++ b/wdio.saucelabs.conf.js
@@ -30,8 +30,8 @@ module.exports = {
   sauceConnectOpts: {
     /*
      * Retry to establish a tunnel 2 times maximum on fail
-     * This is usefull to prevent premature test failure if we have difficulties to open the tunnel
-     * (can append if there is already multiple tunnels opened on SauceLabs)
+     * This is useful to prevent premature test failure if we have difficulties to open the tunnel
+     * (can happen if there are already multiple tunnels opened on SauceLabs)
      * https://github.com/bermi/sauce-connect-launcher#advanced-usage
      */
     connectRetries: 2,

--- a/wdio.saucelabs.conf.js
+++ b/wdio.saucelabs.conf.js
@@ -24,6 +24,20 @@ module.exports = {
    */
   sauceConnect: true,
   /*
+   * Apply Sauce Connect options
+   * https://webdriver.io/docs/sauce-service.html#sauceconnectopts
+   */
+  sauceConnectOpts: {
+    /*
+     * Retry to establish a tunnel 2 times maximum on fail
+     * This is usefull to prevent premature test failure if we have difficulties to open the tunnel
+     * (can append if there is already multiple tunnels opened on SauceLabs)
+     * https://github.com/bermi/sauce-connect-launcher#advanced-usage
+     */
+    connectRetries: 2,
+    connectRetryTimeout: 10000,
+  },
+  /*
    * Sauce Labs Open Source offer has a maximum of 5 concurrent session
    */
   maxInstances: 5,


### PR DESCRIPTION
When running the tests on Circle CI we noticed that sometimes we fail to open the tunnel to SauceLabs, marking the tests as failed. This can be due to too many tunnels opened on SauceLabs at the same time.

This change updates the Sauce Connect configuration to retry the connection if the first attempt fails (with a maximum of 2 retries with a 10sec interval).