### PR TITLE
feat(spec): add custom error messages for timeouts

### DIFF
--- a/helpers/clickHierarchicalMenuItem.ts
+++ b/helpers/clickHierarchicalMenuItem.ts
@@ -14,5 +14,9 @@ browser.addCommand('clickHierarchicalMenuItem', async (label: string) => {
 
   // Changing the URL will also change the page element IDs in Internet Explorer
   // Not waiting for the URL to be properly updated before continuing can make the next tests to fail
-  return browser.waitUntil(async () => (await browser.getUrl()) !== oldUrl);
+  return browser.waitUntil(
+    async () => (await browser.getUrl()) !== oldUrl,
+    undefined,
+    `URL was not updated after click on "${label}" in hierarchical menu`
+  );
 });

--- a/helpers/clickRefinementListItem.ts
+++ b/helpers/clickRefinementListItem.ts
@@ -14,5 +14,9 @@ browser.addCommand('clickRefinementListItem', async (label: string) => {
 
   // Changing the URL will also change the page element IDs in Internet Explorer
   // Not waiting for the URL to be properly updated before continuing can make the next tests to fail
-  return browser.waitUntil(async () => (await browser.getUrl()) !== oldUrl);
+  return browser.waitUntil(
+    async () => (await browser.getUrl()) !== oldUrl,
+    undefined,
+    `URL was not updated after click on "${label}" in refinement list`
+  );
 });

--- a/helpers/setSearchBoxValue.ts
+++ b/helpers/setSearchBoxValue.ts
@@ -24,5 +24,9 @@ browser.addCommand('setSearchBoxValue', async (value: string) => {
 
   // Changing the URL will also change the page element IDs in Internet Explorer
   // Not waiting for the URL to be properly updated before continuing can make the next tests to fail
-  return browser.waitUntil(async () => (await browser.getUrl()) !== oldUrl);
+  return browser.waitUntil(
+    async () => (await browser.getUrl()) !== oldUrl,
+    undefined,
+    `URL was not updated after setting searchbox value to "${value}"`
+  );
 });

--- a/helpers/waitForElement.ts
+++ b/helpers/waitForElement.ts
@@ -5,5 +5,9 @@ declare namespace WebdriverIOAsync {
 }
 
 browser.addCommand('waitForElement', (selector: string) =>
-  browser.waitUntil(async () => (await browser.$$(selector)).length > 0)
+  browser.waitUntil(
+    async () => (await browser.$$(selector)).length > 0,
+    undefined,
+    `Element matching selector "${selector}" wasn't found`
+  )
 );

--- a/specs/initial-state-from-route.spec.ts
+++ b/specs/initial-state-from-route.spec.ts
@@ -136,24 +136,28 @@ describe('InstantSearch - State and route', () => {
     });
 
     it('must have the expected url', async () => {
-      await browser.waitUntil(async () => {
-        const url = await browser.getUrl();
-        const { pathname, searchParams } = new URL(url);
+      await browser.waitUntil(
+        async () => {
+          const url = await browser.getUrl();
+          const { pathname, searchParams } = new URL(url);
 
-        return (
-          pathname ===
-            '/examples/e-commerce/search/Appliances%2FRanges%2C+Cooktops+%26+Ovens/' &&
-          searchParams.get('query') === 'cooktop' &&
-          searchParams.get('page') === '2' &&
-          searchParams.get('brands') === 'Whirlpool' &&
-          searchParams.get('rating') === '3' &&
-          /^(23[0-9]|24[0-9]|250):(124[0-9]|1250)$/.test(
-            searchParams.get('price') || ''
-          ) &&
-          searchParams.get('sortBy') === 'instant_search_price_asc' &&
-          searchParams.get('hitsPerPage') === '64'
-        );
-      });
+          return (
+            pathname ===
+              '/examples/e-commerce/search/Appliances%2FRanges%2C+Cooktops+%26+Ovens/' &&
+            searchParams.get('query') === 'cooktop' &&
+            searchParams.get('page') === '2' &&
+            searchParams.get('brands') === 'Whirlpool' &&
+            searchParams.get('rating') === '3' &&
+            /^(23[0-9]|24[0-9]|250):(124[0-9]|1250)$/.test(
+              searchParams.get('price') || ''
+            ) &&
+            searchParams.get('sortBy') === 'instant_search_price_asc' &&
+            searchParams.get('hitsPerPage') === '64'
+          );
+        },
+        undefined,
+        'URL does not have expected parameters'
+      );
     });
   });
 });

--- a/specs/price-range.spec.ts
+++ b/specs/price-range.spec.ts
@@ -11,14 +11,18 @@ describe('InstantSearch - Search on specific price range', () => {
   });
 
   it(`waits for the results list to be updated (wait for all the prices to be > lowerBound)`, async () => {
-    await browser.waitUntil(async () => {
-      const hits = await browser.$$('.hit-info-container strong');
-      const hitsText = await browser.getTextFromElements(hits);
-      return (
-        hitsText.filter(text => Number(text.replace(',', '')) < lowerBound)
-          .length === 0
-      );
-    });
+    await browser.waitUntil(
+      async () => {
+        const hits = await browser.$$('.hit-info-container strong');
+        const hitsText = await browser.getTextFromElements(hits);
+        return (
+          hitsText.filter(text => Number(text.replace(',', '')) < lowerBound)
+            .length === 0
+        );
+      },
+      undefined,
+      `Results list was not updated to display only hits with prices > ${lowerBound}`
+    );
   });
 
   it('drag and drop upper handle to the left', async () => {
@@ -26,14 +30,18 @@ describe('InstantSearch - Search on specific price range', () => {
   });
 
   it(`waits for the results list to be updated (wait for all the prices to be < upperBound)`, async () => {
-    await browser.waitUntil(async () => {
-      const hits = await browser.$$('.hit-info-container strong');
-      const hitsText = await browser.getTextFromElements(hits);
-      return (
-        hitsText.filter(text => Number(text.replace(',', '')) > upperBound)
-          .length === 0
-      );
-    });
+    await browser.waitUntil(
+      async () => {
+        const hits = await browser.$$('.hit-info-container strong');
+        const hitsText = await browser.getTextFromElements(hits);
+        return (
+          hitsText.filter(text => Number(text.replace(',', '')) > upperBound)
+            .length === 0
+        );
+      },
+      undefined,
+      `Results list was not updated to display only hits with prices < ${upperBound}`
+    );
   });
 
   it('must have the expected results', async () => {


### PR DESCRIPTION
This change adds some custom error messages if a timeout occurs during the test; giving us a clearer explanation of what failed.

**Example**:

Before:
```shell
[chrome 79.0.3945.88 Linux #0-0] 1) InstantSearch - Search on specific category selects "Appliances" category in list
[chrome 79.0.3945.88 Linux #0-0] Error: waitUntil condition timed out after 10000ms
```
After:
```shell
[chrome 79.0.3945.88 Linux #0-1] 1) InstantSearch - Search on specific category selects "Appliances" category in list
[chrome 79.0.3945.88 Linux #0-1] Error: URL was not updated after click on "Appliances" in hierarchical menu
```