### PR TITLE
feat: generate junit test reports by default with saucelabs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ aliases:
 defaults: &defaults
   working_directory: ~/instantsearch-e2-tests
   docker:
-    - image: circleci/node:10.16.3@sha256:6ab62742cec4a68e75e7cac063f6549bae0bcfd0541700df7fde54765eed4ad2
+    - image: cimg/node:10.24
 
 version: 2
 jobs:

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Install `instantsearch-e2e-tests` and its peerDependencies in your InstantSearch
 yarn add --dev \
 algolia/instantsearch-e2e-tests \
 @wdio/cli @wdio/jasmine-framework @wdio/spec-reporter \
-@wdio/static-server-service \
+@wdio/junit-reporter @wdio/static-server-service \
 @wdio/local-runner @wdio/selenium-standalone-service \
 @wdio/sauce-service
 ```

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ exports.config = {
 };
 ```
 
+## Sending reports to CircleCI
+
+CircleCI can [read JUnit XML test metadata files](https://circleci.com/docs/2.0/collect-test-data/) to provide insights on the stability of the test suite. To enable this feature, you can the following key to your e2e job in **.circleci/config.yml**:
+
+```yaml
+  test_e2e:
+  	# ...
+  	steps:
+  		# ...
+  		- store_test_results:
+  			path: junit/wdio
+```
+
 # License
 
 instantsearch-e2-tests is licensed under the [MIT License](http://www.opensource.org/licenses/mit-license.php).

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
   "peerDependencies": {
     "@wdio/cli": "^5.11.13",
     "@wdio/jasmine-framework": "^5.11.0",
+    "@wdio/junit-reporter": "^5.11.7",
     "@wdio/local-runner": "^5.11.13",
     "@wdio/sauce-service": "^5.11.1",
     "@wdio/selenium-standalone-service": "^5.11.2",

--- a/wdio.saucelabs.conf.js
+++ b/wdio.saucelabs.conf.js
@@ -5,6 +5,27 @@ const baseConfig = require('./wdio.base.conf');
 module.exports = {
   ...baseConfig,
   /*
+   * List of reporters to use
+   * https://webdriver.io/docs/options.html#reporters
+   * https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-spec-reporter
+   */
+  reporters: [
+    'spec',
+    [
+      'junit',
+      {
+        outputDir: `${__dirname}/junit/wdio`,
+        outputFileFormat({
+          cid,
+          capabilities: { browserName, browserVersion },
+        }) {
+          return `results-${cid}.${browserName}-${browserVersion}.xml`;
+        },
+        addFileAttribute: true,
+      },
+    ],
+  ],
+  /*
    * Add Sauce Labs integration to WebdriverIO
    * https://webdriver.io/docs/sauce-service.html
    * https://github.com/webdriverio/webdriverio/tree/master/packages/wdio-sauce-service

--- a/yarn.lock
+++ b/yarn.lock
@@ -114,6 +114,16 @@
     deepmerge "^4.0.0"
     glob "^7.1.2"
 
+"@wdio/junit-reporter@^5.11.7":
+  version "5.22.4"
+  resolved "https://registry.yarnpkg.com/@wdio/junit-reporter/-/junit-reporter-5.22.4.tgz#218cba336fe69e88949c54de56967a7daf372286"
+  integrity sha512-qXuFMeBjPthOPDOCNLglOdpLMzjaGrMS5yeatrcH9dG8HDGnCnvDdpIUBTedor5M4Edr5FBMYKeUd0JifGPbqw==
+  dependencies:
+    "@wdio/reporter" "5.22.4"
+    json-stringify-safe "^5.0.1"
+    junit-report-builder "^1.3.0"
+    validator "^13.0.0"
+
 "@wdio/logger@^5.11.0":
   version "5.11.0"
   resolved "https://registry.yarnpkg.com/@wdio/logger/-/logger-5.11.0.tgz#1f74698675c54ffb2114fe4ab945b9a0c1663133"
@@ -130,6 +140,13 @@
   integrity sha512-X7lyvRicOV0nIhRqaDl0Cs2BAd5Ny8zD5/9f9xEpI4T0e/UzixtyMMlAjeJiHLgq9re21xPSqMiBM4Uv8hrxvg==
   dependencies:
     "@wdio/config" "^5.11.0"
+
+"@wdio/reporter@5.22.4":
+  version "5.22.4"
+  resolved "https://registry.yarnpkg.com/@wdio/reporter/-/reporter-5.22.4.tgz#d0ae86980e694e56604fd3f745c55e58335eceef"
+  integrity sha512-y/HIKGJHsKXroWWH1B7upynoYmFMuAwJs3LEVwdnpiJIBF4DxzIrRGCY/SSA6U1a/+cRTdI5m1+vA1gcFxcmwQ==
+  dependencies:
+    fs-extra "^8.0.1"
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -870,6 +887,11 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
+date-format@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/date-format/-/date-format-0.0.2.tgz#fafd448f72115ef1e2b739155ae92f2be6c28dd1"
+  integrity sha1-+v1Ej3IRXvHitzkVWukvK+bCjdE=
+
 dateformat@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-3.0.3.tgz#a6e37499a4d9a9cf85ef5872044d62901c9889ae"
@@ -1417,7 +1439,7 @@ fs-constants@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs-constants/-/fs-constants-1.0.0.tgz#6be0de9be998ce16af8afc24497b9ee9b7ccd9ad"
   integrity sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==
 
-fs-extra@8.1.0:
+fs-extra@8.1.0, fs-extra@^8.0.1:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
   integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
@@ -2020,6 +2042,16 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.10.0"
 
+junit-report-builder@^1.3.0:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/junit-report-builder/-/junit-report-builder-1.3.3.tgz#a848e9ef1b1664b855d1abf8766c39f0a9c5ff33"
+  integrity sha512-75bwaXjP/3ogyzOSkkcshXGG7z74edkJjgTZlJGAyzxlOHaguexM3VLG6JyD9ZBF8mlpgsUPB1sIWU4LISgeJw==
+  dependencies:
+    date-format "0.0.2"
+    lodash "^4.17.15"
+    mkdirp "^0.5.0"
+    xmlbuilder "^10.0.0"
+
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-3.2.2.tgz#31ea21a734bab9bbb0f32466d893aea51e4a3c64"
@@ -2188,6 +2220,11 @@ lodash@4.17.15, lodash@^4.14.14, lodash@^4.17.12, lodash@^4.17.14, lodash@^4.2.1
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.15:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
 loglevel-plugin-prefix@^0.8.4:
   version "0.8.4"
   resolved "https://registry.yarnpkg.com/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz#2fe0e05f1a820317d98d8c123e634c1bd84ff644"
@@ -2342,6 +2379,11 @@ minimist@1.2.0, minimist@^1.1.3:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
   integrity sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=
 
+minimist@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
 minimist@~0.0.1:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
@@ -2354,6 +2396,13 @@ mixin-deep@^1.2.0:
   dependencies:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
+
+mkdirp@^0.5.0:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
+  integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+  dependencies:
+    minimist "^1.2.5"
 
 mkdirp@^0.5.1:
   version "0.5.1"
@@ -3529,6 +3578,11 @@ validate-npm-package-license@^3.0.1:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
 
+validator@^13.0.0:
+  version "13.7.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.7.0.tgz#4f9658ba13ba8f3d82ee881d3516489ea85c0857"
+  integrity sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
@@ -3602,6 +3656,11 @@ write@1.0.3:
   integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
   dependencies:
     mkdirp "^0.5.1"
+
+xmlbuilder@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-10.1.1.tgz#8cae6688cc9b38d850b7c8d3c0a4161dcaf475b0"
+  integrity sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
BREAKING CHANGE: tested projects now require `@wdio/junit-reporter`.