### PR TITLE
fix: correctly output junit report in target repository

### DIFF
--- a/wdio.saucelabs.conf.js
+++ b/wdio.saucelabs.conf.js
@@ -14,7 +14,7 @@ module.exports = {
     [
       'junit',
       {
-        outputDir: `${__dirname}/junit/wdio`,
+        outputDir: `${process.cwd()}/junit/wdio`,
         outputFileFormat({
           cid,
           capabilities: { browserName, browserVersion },


### PR DESCRIPTION
A previous PR added automatic JUnit report generation for tested projects. Unfortunately, those reports were generated in **node_modules/instantsearch-e2e-tests** instead of the root of the tested repositories.

This PR fixes that.

> **ci/circleci: test** is expected to fail since the test suite includes react-instantsearch and vue-instantsearch, which don't have @wdio/junit-reporter, a mandatory dependency starting from #29.